### PR TITLE
Fix: Add missing import shutil

### DIFF
--- a/learning/train.py
+++ b/learning/train.py
@@ -3,6 +3,7 @@ import sys
 import hydra
 import torch
 import logging
+import shutil
 import numpy as np
 from omegaconf import DictConfig
 from stable_baselines3 import PPO


### PR DESCRIPTION
There was an error before as we had not imported shutil. I changed it such that we import shutil.